### PR TITLE
Add PR and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Report a bug you've found in the package.
+title: "[BUG]"
+labels: "bug"
+---
+
+## Description
+
+<!-- Describe the bug here. Be sure to include:
+- What you were trying to do.
+- Which features / parts of the package you were using.
+- What you expected to happen.
+- What actually happened.
+ -->
+
+## Minimal Steps to Reproduce
+
+<!-- If you can, please include here a minimal sequence of steps that will allow us to reproduce the bug. -->
+
+## Desired Outcome
+
+<!-- Describe what you think should be happening, or what you would like to happen, to fix this bug. -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,17 +7,17 @@ labels: "bug"
 
 ## Description
 
-<!-- Describe the bug here. Be sure to include:
+Describe the bug here. Be sure to include:
+
 - What you were trying to do.
 - Which features / parts of the package you were using.
 - What you expected to happen.
 - What actually happened.
- -->
 
 ## Minimal Steps to Reproduce
 
-<!-- If you can, please include here a minimal sequence of steps that will allow us to reproduce the bug. -->
+If you can, please include here a minimal sequence of steps that will allow us to reproduce the bug.
 
 ## Desired Outcome
 
-<!-- Describe what you think should be happening, or what you would like to happen, to fix this bug. -->
+Describe what you think should be happening, or what you would like to happen, if you didn't encounter the bug.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Report a bug you've found in the package.
+title: "[BUG]"
+labels: "bug"
+---
+
+## Description
+
+<!-- Describe the bug here. Be sure to include:
+- What you were trying to do.
+- Which features / parts of the package you were using.
+- What you expected to happen.
+- What actually happened.
+ -->
+
+## Minimal Steps to Reproduce
+
+<!-- If you can, please include here a minimal sequence of steps that will allow us to reproduce the bug. -->
+
+## Desired Outcome
+
+<!-- Describe what you think should be happening, or what you would like to happen, to fix this bug. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,23 +1,18 @@
 ---
 name: Feature Request
-about: Report a bug you've found in the package.
-title: "[BUG]"
-labels: "bug"
+about: Describe a feature you'd like to see implemented.
+title: "[FEATURE]"
+labels: "enhancement"
 ---
 
 ## Description
 
-<!-- Describe the bug here. Be sure to include:
-- What you were trying to do.
-- Which features / parts of the package you were using.
-- What you expected to happen.
-- What actually happened.
- -->
+### What is this feature?
 
-## Minimal Steps to Reproduce
+Describe what the feature should be, how it should work, and what it should produce.
 
-<!-- If you can, please include here a minimal sequence of steps that will allow us to reproduce the bug. -->
+Include an example use-case for the feature, and potential mock-ups of the API / function calls necessary to use it.
 
-## Desired Outcome
+### Why is this feature needed?
 
-<!-- Describe what you think should be happening, or what you would like to happen, to fix this bug. -->
+Explain why the package would benefit from this feature being implemented.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!-- Thank you for contributing to `assignment-submission-checker`!
+
+Before opening your pull request, make sure you read the [contributing guide](https://ucl-comp0233-24-25.github.io/assignment-submission-checker/contributing.html#contributing-code).
+
+Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and tag @UCL-COMP0233-24-25/comp0233-admin, and one of us will come and help :)
+-->
+
+# What is this PR?
+
+- [ ] Bug fix :bug:
+- [ ] Addition of a new feature :rocket:
+- [ ] Documentation update :page_with_curl:
+- [ ] CI / infrastructure improvement :wrench:
+- [ ] Other :shrug:
+
+## Why is this PR needed?
+
+If this PR directly addresses an issue, please link to the issue(s) here.
+
+Otherwise, please describe why this PR is necessary.
+
+## What does this PR do?
+
+Please describe what you have implemented in this PR, and how it addresses the problems you mentioned above (if any).
+
+## How has this PR been tested?
+
+Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.
+
+## Is this a breaking change?
+
+If this PR breaks any existing functionality, please explain how and why.
+
+## Checklist
+
+- [ ] The code introduced in this PR has been tested locally.
+- [ ] Appropriate tests have been added to cover any new functionality.
+- [ ] The documentation has been updated to reflect any changes.
+- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/).

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -10,7 +10,8 @@ The `specs` folder contains `.json` specifications that the `assignment-submissi
 To add an assignment specification, simply add a file to this folder using the [naming convention](#naming-convention) outlined below.
 You can also [check the existing specifications][current-specs-folder] and use them as a template.
 
-```{admonition} Do not delete this folder!
+```{danger}
+**Do not delete this folder!**
 The `assignment-checker` needs to be able to fetch assignment specifications, and it expects to find them here.
 
 If this folder is relocated, `assignment_submission_checker.cli:ASSIGNMENT_SPEC_REFERENCES` needs to be correspondingly updated too.

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -77,6 +77,37 @@ You can speed up the process by including a helpful title and description in you
 
 If you are planning to contribute code, you might also want to take a look at our [API Reference](./api.md) to familiarise yourself with the codebase.
 
+### Developer Install
+
+If you are planning to contribute to this repository, we recommend you install this package with it's optional `dev` dependency, and using an editable install.
+To do so using `pip`;
+
+1. Clone (your fork of) this repository locally.
+2. Open a terminal in the repository root.
+3. Create a new environment for developing this package.
+4. Run `pip install -e .[dev]` to install the package in editable mode, and fetch the optional dependencies.
+
+### Pre-commit
+
+This repository uses [pre-commit](https://pre-commit.com/) to format files tracked by the repository, which is included in the `[dev]` optional dependencies.
+Once you have installed pre-commit in your developer environment, run
+
+```bash
+pre-commit install
+```
+
+to initialise pre-commit for this project.
+This will ensure that all the pre-commit checks run after you try and make a commit, and it will flag any issues with your formatting.
+The hook will also attempt to fix any mistakes it finds, though you will need to `git add` these changes before you commit again.
+
+Once pre-commit is installed, you can also run
+
+```bash
+pre-commit run -a
+```
+
+to run pre-commit across all files in the repository at any time.
+
 ## Building the Documentation
 
 The documentation is built [using `Sphinx`][sphinx] and deployed via GitHub actions whenever a push to `main` occurs.

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -60,8 +60,14 @@ This creates a nested structure of key-value entries, representative of the dire
 
 ## Reporting a Bug
 
-If you encounter a bug in the submission checker, please [open an issue][repo-issues].
-In your bug report, please include steps to replicate the bug that you encountered, plus any other relevant information such as the assignment specs you were trying to check against.
+If you encounter a bug in the submission checker, please [open an issue][repo-issues] and use the "bug report" template.
+Please fill out each section in the template with as much detail as you can provide, as this will help us fix the issue faster.
+
+## Requesting a Feature
+
+If you would like to suggest a feature to be added to the package, please [open an issue][repo-issues] and use the "feature request" template.
+Please take the time to fill out each of the sections in the template, and be as clear as possible.
+The maintainers will review your feature request at their earliest opportunity, however you can always open a PR [to contribute](#contributing-code) the feature yourself.
 
 ## Contributing Code
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -29,7 +29,9 @@ This ensures that any local copies of your repository are not affected by runnin
 The `assignment-checker` reads the specifications it is checking against from a file, which it needs to fetch from the internet when it is run.
 These files can be [viewed and downloaded][assignment-specs-readme] manually here, if you want to run the checker offline with the `-l` or `--local-specs` options.
 
-```{admonition} Disclaimer
+```{attention}
+**Disclaimer**
+
 The `assignment-checker` command-line program does **not** provide any reflection or indication of the grade you may receive for a submission you make.
 It only checks whether the organisational structure of your submission matches that which is laid out in the assignment guidelines, so that you can be certain that your submission conforms to said specifications prior to making your submission.
 

--- a/docs/source/users.md
+++ b/docs/source/users.md
@@ -7,7 +7,9 @@
 
 Users should use `pip` to install this package.
 
-```{admonition} Which Environment To Install Into?
+```{tip}
+**Which Environment To Install Into?**
+
 We recommend that you install this package into your `COMP0233` environment, and **not** into the same environment that you are working on your solution in.
 This package will install external dependencies that may conflict with those your assignment's solution requires, or install packages that your assignment should not make use of.
 If you are using the `COMP0233` environment to write your solution, consider making a separate environment for this package to be installed into.


### PR DESCRIPTION
Resolves #4 |

- Adds PR and issue templates (for bugs and feature requests)
- Updates documentation to use specific "admonition" blocks
- Updates dev docs to mention pre-commit hook, and a short install tutorial for it