### PR TITLE
Fix GH Clones Needing Explicit Directory Name

### DIFF
--- a/assignment_submission_checker/assignment.py
+++ b/assignment_submission_checker/assignment.py
@@ -166,7 +166,7 @@ class Assignment:
                 "Information reported here does not invalidate the submission, "
                 "though you may wish to check you expect everything here to apply "
                 "to your submission.\n\t"
-            ) + "\n".join(s.replace("\n", "\n\t") for s in information)
+            ) + "\n\t".join(s.replace("\n", "\n\t") for s in information)
 
         if (not fatal_str) and (not warnings_str) and (not information_str):
             return f"{heading_str}\nSubmission format matches specifications, nothing further to report."

--- a/assignment_submission_checker/directory.py
+++ b/assignment_submission_checker/directory.py
@@ -530,12 +530,14 @@ class Directory:
 
         if not path_to_subdir.is_dir():
             if subdir.is_optional:
-                information.append(f"Optional subfolder {subdir.name} of {self.name} not found.")
+                information.append(
+                    f"Optional subfolder '{subdir.name}' of '{self.name}' not found."
+                )
                 return None, warning, information
             else:
                 return (
                     AssignmentCheckerError(
-                        f"Expected subdirectory {subdir.name} to be present in {self.name}, but it is not."
+                        f"Expected subdirectory '{subdir.name}' to be present in '{self.name}', but it is not."
                     ),
                     warning,
                     information,


### PR DESCRIPTION
<!-- Thank you for contributing to `assignment-submission-checker`!

Before opening your pull request, make sure you read the [contributing guide](https://ucl-comp0233-24-25.github.io/assignment-submission-checker/contributing.html#contributing-code).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and tag @UCL-COMP0233-24-25/comp0233-admin, and one of us will come and help :)
-->

# What is this PR?

- [x] Bug fix :bug:
- [ ] Addition of a new feature :rocket:
- [ ] Documentation update :page_with_curl:
- [ ] CI / infrastructure improvement :wrench:
- [ ] Other :shrug:

## Why is this PR needed?

Cloning from GH via GitPython places the repository root in the target directory, it does not create a new directory with the repository name and insert it into the target directory.

This was causing the `-g` option to flag submissions as incorrect because the top-level folder did not match the expected naming pattern.

## What does this PR do?

Repos that are fetched from GitHub now have their name inferred, and are relocated to a temporary directory with this name.

## How has this PR been tested?

## Is this a breaking change?

## Checklist

- [x] The code introduced in this PR has been tested locally.
- [ ] Appropriate tests have been added to cover any new functionality.
- [x] The documentation has been updated to reflect any changes.
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/).
