### PR TITLE
Allow `git`-metadata files by default.

### DIFF
--- a/assignment_submission_checker/directory.py
+++ b/assignment_submission_checker/directory.py
@@ -404,11 +404,10 @@ class Directory:
             file for pattern in self.data_file_patterns for file in fnmatch.filter(files, pattern)
         )
         unexpected = files - set(self.compulsory) - set(self.optional) - data_files
+        git_files = set()
         if self.git_root:
             # Do not report git files as unexpected if we're at the git root.
             # Add these as optionals
-            git_files = set()
-
             for file in unexpected:
                 if any(fnmatch(file.lower(), pattern.lower()) for pattern in GIT_ROOT_PATTERNS):
                     git_files.add(file)

--- a/assignment_submission_checker/directory.py
+++ b/assignment_submission_checker/directory.py
@@ -415,7 +415,7 @@ class Directory:
 
             unexpected = unexpected - git_files
 
-        optional = files - unexpected - set(self.compulsory) + git_files
+        optional = (files - unexpected - set(self.compulsory)).union(git_files)
 
         return missing_compulsory, unexpected, optional
 

--- a/assignment_submission_checker/git_utils.py
+++ b/assignment_submission_checker/git_utils.py
@@ -6,6 +6,15 @@ import git
 
 from .utils import AssignmentCheckerError
 
+GIT_ROOT_PATTERNS = [
+    "README*",
+    "LICENSE*",
+    "*.ini",
+    "*.in",
+    "*.yaml",
+    ".gitignore",
+]
+
 
 def is_clean(
     repo: git.Repo, boolean_output: bool = False

--- a/specs/2024-001.json
+++ b/specs/2024-001.json
@@ -31,6 +31,11 @@
             "data-file-types": [
                 "*.csv"
             ]
+        },
+        ".github": {
+            "data-file-types": [
+                "*"
+            ]
         }
     }
 }

--- a/tests/directory/test_basics.py
+++ b/tests/directory/test_basics.py
@@ -14,7 +14,6 @@ def test_init(template_directory: Directory):
     assert not template_directory.optional
     assert not template_directory.is_optional
     assert not template_directory.data_file_patterns
-    assert not template_directory.is_data_dir
     assert template_directory.variable_name
     assert template_directory.path_from_root == Path(".")
     assert len(template_directory.subdirs) == 1
@@ -35,7 +34,6 @@ def test_init(template_directory: Directory):
     assert (
         data_dir.is_optional
     ), "No compulsory files (nor subdirs to recurse into) should imply directory is optional"
-    assert data_dir.is_data_dir
     assert data_dir.path_from_root == Path(path_to_data)
     assert data_dir.parent is repo_directory
 


### PR DESCRIPTION
<!-- Thank you for contributing to `assignment-submission-checker`!

Before opening your pull request, make sure you read the [contributing guide](https://ucl-comp0233-24-25.github.io/assignment-submission-checker/contributing.html#contributing-code).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and tag @UCL-COMP0233-24-25/comp0233-admin, and one of us will come and help :)
-->

# What is this PR?

- [ ] Bug fix :bug:
- [x] Addition of a new feature :rocket:
- [ ] Documentation update :page_with_curl:
- [ ] CI / infrastructure improvement :wrench:
- [ ] Other :shrug:

## Why is this PR needed?

Ensures that git files like README, LICENSE, `pre-commit-config.yaml`, etc are treated as optional by the checker

## What does this PR do?

`Directory.check_files` now includes a sub-case for when the directory in question is the repo root.

## How has this PR been tested?

## Is this a breaking change?

## Checklist

- [ ] The code introduced in this PR has been tested locally.
- [ ] Appropriate tests have been added to cover any new functionality.
- [ ] The documentation has been updated to reflect any changes.
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/).
